### PR TITLE
Problem: Including library header breaks C library interface.

### DIFF
--- a/include/fty-log/fty_logger.h
+++ b/include/fty-log/fty_logger.h
@@ -30,9 +30,6 @@
 #define streq(s1,s2) (!strcmp ((s1), (s2)))
 #endif
 
-//  Include the project library file
-#include "fty_common_logging_library.h"
-
 #ifdef __cplusplus
 #include <cxxtools/log.h>
 #endif


### PR DESCRIPTION
Solution: Do not include it (it looks we do not need it).

Signed-off-by: Jana Rapava <janarapava@eaton.com>
***********************************************************************
Complexity: S
Impact: M