### PR TITLE
Fix double output in verbose mode

### DIFF
--- a/include/fty-log/fty_logger.h
+++ b/include/fty-log/fty_logger.h
@@ -147,6 +147,9 @@ private:
   //Set the console appender
   void setConsoleAppender();
 
+  // Remove instances of log4cplus::ConsoleAppender from a given logger
+  static void removeConsoleAppenders(log4cplus::Logger logger);
+
   //Set log level with level from syslog.h for debug, info, warning, error and fatal
   // log level set to trace level otherwise
   void setLogLevelFromEnv(const std::string& level);

--- a/src/fty-log/fty_logger.cc
+++ b/src/fty-log/fty_logger.cc
@@ -148,6 +148,21 @@ void Ftylog::setConsoleAppender()
   _logger.addAppender(append);
 }
 
+void Ftylog::removeConsoleAppenders(log4cplus::Logger logger)
+{
+  for (log4cplus::SharedAppenderPtr & appenderPtr : logger.getAllAppenders())
+  {
+    log4cplus::Appender & app = *appenderPtr;
+
+    if (typeid (app) == typeid (log4cplus::ConsoleAppender))
+    {
+      //If any, remove it
+      logger.removeAppender(appenderPtr);
+      break;
+    }
+  }
+}
+
 //Switch the logging system to verbose
 void Ftylog::setVeboseMode()
 {
@@ -155,18 +170,11 @@ void Ftylog::setVeboseMode()
   log4cplus::LogLevel oldLevel = _logger.getLogLevel();
   //set log level of the logger to TRACE
   setLogLevelTrace();
-  //Search if a console appender already exist
-  for (log4cplus::SharedAppenderPtr & appenderPtr : _logger.getAllAppenders())
-  {
-    log4cplus::Appender & app = *appenderPtr;
-
-    if (typeid (app) == typeid (log4cplus::ConsoleAppender))
-    {
-      //If any, remove it
-      _logger.removeAppender(appenderPtr);
-      break;
-    }
-  }
+  //Search if a console appender already exist in our logger instance or in
+  //the root logger (we assume a flat hierarchy with the root logger and
+  //specialized instances directly below the root logger)
+  removeConsoleAppenders(_logger);
+  removeConsoleAppenders(log4cplus::getDefaultHierarchy().getRoot());
 
   //Set all remaining appenders with the old log level as threshold if not defined
   for (log4cplus::SharedAppenderPtr & appenderPtr : _logger.getAllAppenders())


### PR DESCRIPTION
In Ftylog::setVeboseMode [sic], we try to remove any existing console
appender from the logger instance, but the configuration file typically
defines a console appender for the root logger, resulting in duplicate
output from the root logger and our logger instance.