### PR TITLE
Problem: can not set LOG_TRACE explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ and the log4cplus level set by default then:
 | LOG_WARNING         |     WARN         |
 | LOG_INFO            |     INFO         |
 | LOG_DEBUG           |     DEBUG        |
+| LOG_TRACE           |     TRACE        |
 | LOG_OFF             |     OFF          |
 | Other               |     TRACE        |
 

--- a/src/fty-log/fty_logger.cc
+++ b/src/fty-log/fty_logger.cc
@@ -306,6 +306,10 @@ bool Ftylog::setLogLevelFromEnvDefinite(const std::string& level)
     //If empty string, set nothing and return false
     return false;
   }
+  else if (level == "LOG_TRACE")
+  {
+    setLogLevelTrace();
+  }
   else if (level == "LOG_DEBUG")
   {
     setLogLevelDebug();


### PR DESCRIPTION
Solution: beside having it as fallback in some cases, support the "LOG_TRACE" value for the envvars like BIOS_LOG_LEVEL and BIOS_LOG_INIT_LEVEL

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>