### PR TITLE
 Problem: docs and comments confuse casing of Ftylog name

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ for more information about appenders.
 ### Verbose mode
 
 For an agent with a verbose mode, you can call the C++ class method
-`FtyLog::setVerboseMode()` (or `ftylog_setVerboseMode(Ftylog* log)`
+`Ftylog::setVerboseMode()` (or `ftylog_setVerboseMode(Ftylog* log)`
 for C code) to change the logging system :
 
 * It sets (or overwrites if existing) a `ConsoleAppender` object with
@@ -207,12 +207,12 @@ for C code) to change the logging system :
 The following C++ class functions test if a log level is included in the
 log level of the agent :
 
-* `bool FtyLog::isLogTrace()`
-* `bool FtyLog::isLogDebug()`
-* `bool FtyLog::isLogInfo()`
-* `bool FtyLog::isLogWarning()`
-* `bool FtyLog::isLogError()`
-* `bool FtyLog::isLogFatal()`
+* `bool Ftylog::isLogTrace()`
+* `bool Ftylog::isLogDebug()`
+* `bool Ftylog::isLogInfo()`
+* `bool Ftylog::isLogWarning()`
+* `bool Ftylog::isLogError()`
+* `bool Ftylog::isLogFatal()`
 
 And for C code :
 
@@ -232,12 +232,12 @@ The following methods change dynamically the logging level of the `Ftylog`
 object to a specific log level, so **only use it for testing**.
 
 This class methods are :
-* `void FtyLog::setLogLevelTrace()`
-* `void FtyLog::setLogLevelDebug()`
-* `void FtyLog::setLogLevelInfo()`
-* `void FtyLog::setLogLevelWarning()`
-* `void FtyLog::setLogLevelError()`
-* `void FtyLog::setLogLevelFatal()`
+* `void Ftylog::setLogLevelTrace()`
+* `void Ftylog::setLogLevelDebug()`
+* `void Ftylog::setLogLevelInfo()`
+* `void Ftylog::setLogLevelWarning()`
+* `void Ftylog::setLogLevelError()`
+* `void Ftylog::setLogLevelFatal()`
 
 And for C code :
 * `void ftylog_setLogLevelTrace(Ftylog * log)`

--- a/include/fty-log/fty_logger.h
+++ b/include/fty-log/fty_logger.h
@@ -185,7 +185,7 @@ public:
   //And try to load it
   void setConfigFile(std::string file);
 
-  //Change properties of the FtyLog object
+  //Change properties of the Ftylog object
   void change(std::string name,std::string configFile);
 
   //Set the logger to a specific log level


### PR DESCRIPTION
Solution: fix casing so info sources are more reliable

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>