### PR TITLE
Problem: veRbose is spelled differently than in our ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ for more information about appenders.
 ### Verbose mode
 
 For an agent with a verbose mode, you can call the C++ class method
-`Ftylog::setVeboseMode()` (or `ftylog_setVeboseMode(Ftylog* log)`
+`Ftylog::setVerboseMode()` (or `ftylog_setVerboseMode(Ftylog* log)`
 for C code) to change the logging system :
 
 * It sets (or overwrites if existing) a `ConsoleAppender` object with

--- a/include/fty-log/fty_logger.h
+++ b/include/fty-log/fty_logger.h
@@ -226,7 +226,8 @@ public:
   // -For the other appender, set the threshold parameter to the old logger log level
   //    if no loglevel defined for this appender
   // -Add a new console appender
-  void setVeboseMode();
+  void setVerboseMode();
+  void setVeboseMode(); // legacy misnomer
 
   /**
    * Set a context for a mapped diagnostic context (MDC)
@@ -308,7 +309,8 @@ void ftylog_insertLog(Ftylog * log, int level, const char* file, int line,
 // -For the other appender, set the threshold parameter to the old logger log level
 //    if no loglevel defined for this appender
 // -Add a new console appender
-void ftylog_setVeboseMode(Ftylog * log);
+void ftylog_setVerboseMode(Ftylog * log);
+void ftylog_setVeboseMode(Ftylog * log); // legacy misnomer
 
 // Return the Ftylog obect from the instance (C code)
 Ftylog * ftylog_getInstance();

--- a/src/fty-log/fty_logger.cc
+++ b/src/fty-log/fty_logger.cc
@@ -166,7 +166,12 @@ void Ftylog::removeConsoleAppenders(log4cplus::Logger logger)
 }
 
 //Switch the logging system to verbose
-void Ftylog::setVeboseMode()
+void Ftylog::setVeboseMode() // legacy misnomer
+{
+  setVerboseMode();
+}
+
+void Ftylog::setVerboseMode()
 {
   //Save the loglevel of the logger
   log4cplus::LogLevel oldLevel = _logger.getLogLevel();
@@ -598,9 +603,14 @@ void ftylog_insertLog(Ftylog * log, int level, const char* file, int line,
 }
 
 //Switch to verbose mode
-void ftylog_setVeboseMode(Ftylog * log)
+void ftylog_setVeboseMode(Ftylog * log) // legacy misnomer
 {
-  log->setVeboseMode();
+  log->setVerboseMode();
+}
+
+void ftylog_setVerboseMode(Ftylog * log)
+{
+  log->setVerboseMode();
 }
 
 Ftylog * ftylog_getInstance()
@@ -714,9 +724,14 @@ void fty_common_log_fty_log_test(bool verbose)
   printf(" * Check log config file test : OK\n");
 
   printf(" * Check verbose \n");
-  test->setVeboseMode();
+  test->setVerboseMode();
   log_trace_log(test, "This is a verbose trace log");
   printf(" * Check verbose : OK \n");
+
+  printf(" * Check legacy misnamed vebose \n");
+  test->setVeboseMode();
+  log_trace_log(test, "This is a legacy misnamed vebose trace log");
+  printf(" * Check legacy misnamed vebose : OK \n");
 
   //delete the log file test
   remove("./src/selftest-rw/logfile.log");


### PR DESCRIPTION
Solution: provide properly named routines, provide erroneous name for existing unfixed components

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>

Note: we have dozens of components actually using the misspelled name (since there was none other), but this PR opens the door to doing the right thing in new components (and slowly fixing existing ones).